### PR TITLE
ingredient-input-form actually uses the args passed in from the <input/> component

### DIFF
--- a/client/components/ingredient-form-input.jsx
+++ b/client/components/ingredient-form-input.jsx
@@ -19,18 +19,11 @@ var IngredientFormInput = React.createClass({
     };
   },
 
-  handleChange: function () {
-    var newValue = this.refs.input.getDOMNode().value;
-
-    RecipeActions.inputChanged({
-      _id: this.props._id,
-      accessor: this.props.accessor,
-      index: this.props.index,
-      value: newValue
-    });
+  handleChange: function (data) {
+    RecipeActions.inputChanged(data);
 
     this.setState({
-      value: newValue
+      value: data.value
     });
   },
 


### PR DESCRIPTION
If I managed to follow the code, this is what should probably be used by the higher level ingredient input, instead of peeking into its inner <input/> data